### PR TITLE
feat: 랜턴 목록 및 상세 모바일 구현 / 랜턴 sse 실시간 캐시 가져오기

### DIFF
--- a/src/components/common/lantern/VideoFeed.tsx
+++ b/src/components/common/lantern/VideoFeed.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import Webcam from 'react-webcam';
 import { video } from './video.css';
+import { MOBILE_MIN_WIDTH } from '@/styles/mediaQuery';
 
 export type VideoFeedRef = {
   getVideoElement: () => HTMLVideoElement | null;
@@ -13,6 +14,7 @@ export const VideoFeed = forwardRef<VideoFeedRef>((_, ref) => {
     getVideoElement: () => webcamRef.current?.video || null,
   }));
 
+  if (window.innerWidth <= MOBILE_MIN_WIDTH) return null;
   return (
     <div className={video.container}>
       <Webcam className={video.invisibleVideo} ref={webcamRef} audio={false} />

--- a/src/pages/lantern/Lantern.css.ts
+++ b/src/pages/lantern/Lantern.css.ts
@@ -2,11 +2,24 @@ import { keyframes, style } from '@vanilla-extract/css';
 import { clearLanternCustom } from '../entry/Entry.css';
 import { colors } from '@/styles/color.css';
 import { fonts } from '@/styles/font.css';
+import { MOBILE_MIN_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 export const container = style({
   width: '100vw',
   height: '100vh',
   background: 'linear-gradient(180deg, #000 0%, #185393 100%)',
+
+  '@media': {
+    [MOBILE_MIN_MEDIA_QUERY]: {
+      transform: 'rotate(90deg)',
+      transformOrigin: 'center center',
+      width: '100vh',
+      height: '100vw',
+      position: 'fixed',
+      top: 'calc((100vh - 100vw) / 2)',
+      left: 'calc((100vw - 100vh) / 2)',
+    },
+  },
 });
 
 export const lanternBox = style({

--- a/src/pages/lantern/Lantern.tsx
+++ b/src/pages/lantern/Lantern.tsx
@@ -13,8 +13,7 @@ import { Alert } from '@/components/common/alert';
 import { LanternWithRect } from '@/components/common/lantern/constants';
 import { useLanternHit } from '@/components/common/lantern/hooks/useLanternHit';
 import { useLanternList } from '@/queries/lantern/getLanternList';
-import { queryClient } from '@/queries/queryClient';
-import { lanternKeys } from '@/queries/queryKey';
+import { useCachedLanternProgress } from '@/queries/lantern/useLanternProgress';
 import { MOBILE_MIN_WIDTH } from '@/styles/mediaQuery';
 
 const LanternItem = ({
@@ -120,24 +119,19 @@ const Lantern = () => {
   }, [data, window.innerWidth, window.innerHeight, closeButtonRect]);
 
   // 내 풍등 완료 여부 확인
+  const { data: progressData } = useCachedLanternProgress(currentLanternId);
   useEffect(() => {
     if (!currentLanternId) return;
 
-    const cachedProgress = queryClient.getQueryData<MusicStatusData | MusicStatusData[]>(
-      lanternKeys.progress(currentLanternId),
-    );
-    const successLanterns = JSON.parse(localStorage.getItem('successLanterns') || '[]');
     const isCompleted =
-      Array.isArray(cachedProgress) ||
-      (cachedProgress && (cachedProgress as MusicStatusData)?.status === 'success') ||
-      successLanterns.includes(currentLanternId);
+      Array.isArray(progressData) || (progressData && (progressData as MusicStatusData)?.status === 'success');
 
     if (isCompleted) {
       setTimeout(() => {
         setIsMyLanternCompleted(true);
       }, 1000);
     }
-  }, [currentLanternId, queryClient]);
+  }, [currentLanternId, progressData]);
 
   const { hitLanternId } = useLanternHit(lanterns);
 

--- a/src/pages/lantern/Lantern.tsx
+++ b/src/pages/lantern/Lantern.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import * as styles from './Lantern.css';
 import { generateNonOverlappingPositions, seededRandom } from './utils';
+import { CloseButton } from '../lanternDetail/components/CloseButton/CloseButton';
+import { useCloseGesture } from '../lanternDetail/hooks/useCloseGesture';
 import { useHandMark } from '../../components/common/lantern/hooks/useHandMark';
 import { VideoFeed } from '../../components/common/lantern/VideoFeed';
 import { MusicStatusData } from '@/apis/lantern/subscribeStatus';
@@ -15,7 +17,15 @@ import { queryClient } from '@/queries/queryClient';
 import { lanternKeys } from '@/queries/queryKey';
 import { MOBILE_MIN_WIDTH } from '@/styles/mediaQuery';
 
-const LanternItem = ({ lantern, isDelayed = false }: { lantern: LanternWithRect; isDelayed?: boolean }) => {
+const LanternItem = ({
+  lantern,
+  isDelayed = false,
+  onClick,
+}: {
+  lantern: LanternWithRect;
+  isDelayed?: boolean;
+  onClick: () => void;
+}) => {
   return (
     <div
       className={styles.lanternBox}
@@ -31,6 +41,7 @@ const LanternItem = ({ lantern, isDelayed = false }: { lantern: LanternWithRect;
           : undefined,
         animationDelay: isDelayed ? '1s' : undefined,
       }}
+      onClick={onClick}
     >
       {lantern.ImageComponent && (
         <lantern.ImageComponent
@@ -53,6 +64,7 @@ const Lantern = () => {
   const navigate = useNavigate();
   const [isMyLanternCompleted, setIsMyLanternCompleted] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   // 풍등 정보 없을 경우 리다이렉트
   useEffect(() => {
@@ -118,13 +130,30 @@ const Lantern = () => {
   const lanternsWithoutMine = lanterns.filter((l) => l.lantern_id !== currentLanternId);
   const myLantern = lanterns.find((l) => l.lantern_id === currentLanternId);
 
+  useCloseGesture(closeButtonRef);
+  const handleCloseClick = () => {
+    navigate('/');
+  };
+
   return (
     <div className={styles.container}>
+      <CloseButton ref={closeButtonRef} onClick={handleCloseClick} />
       <VideoFeed />
       {lanternsWithoutMine.map((lantern) => (
-        <LanternItem key={lantern.lantern_id} lantern={lantern} />
+        <LanternItem
+          key={lantern.lantern_id}
+          lantern={lantern}
+          onClick={() => navigate(`/lanterns/${lantern.lantern_id}?currentLanternId=${currentLanternId}`)}
+        />
       ))}
-      {isMyLanternCompleted && myLantern && <LanternItem key={myLantern.lantern_id} lantern={myLantern} isDelayed />}
+      {isMyLanternCompleted && myLantern && (
+        <LanternItem
+          key={myLantern.lantern_id}
+          lantern={myLantern}
+          isDelayed
+          onClick={() => navigate(`/lanterns/${myLantern.lantern_id}?currentLanternId=${currentLanternId}`)}
+        />
+      )}
       {handCenter && <div className={styles.handPointer} style={{ top: handCenter.y, left: handCenter.x }} />}
       <Alert
         isOpen={showAlert}

--- a/src/pages/lantern/Lantern.tsx
+++ b/src/pages/lantern/Lantern.tsx
@@ -13,6 +13,7 @@ import { useLanternHit } from '@/components/common/lantern/hooks/useLanternHit';
 import { useLanternList } from '@/queries/lantern/getLanternList';
 import { queryClient } from '@/queries/queryClient';
 import { lanternKeys } from '@/queries/queryKey';
+import { MOBILE_MIN_WIDTH } from '@/styles/mediaQuery';
 
 const LanternItem = ({ lantern, isDelayed = false }: { lantern: LanternWithRect; isDelayed?: boolean }) => {
   return (
@@ -66,7 +67,12 @@ const Lantern = () => {
 
   const lanterns = useMemo(() => {
     const ids = (data?.data ?? []).map((l) => l.lantern_id);
-    const positionMap = generateNonOverlappingPositions(ids, 100, window.innerWidth, window.innerHeight);
+    const positionMap = generateNonOverlappingPositions(
+      ids,
+      window.innerWidth <= MOBILE_MIN_WIDTH ? 60 : 100,
+      window.innerWidth <= MOBILE_MIN_WIDTH ? window.innerHeight : window.innerWidth,
+      window.innerWidth <= MOBILE_MIN_WIDTH ? window.innerWidth : window.innerHeight,
+    );
     const lanternImages = [LanternImg1, LanternImg2];
 
     return (data?.data ?? []).map((lantern) => ({
@@ -79,7 +85,7 @@ const Lantern = () => {
       rotation: seededRandom((lantern as { lantern_id: string }).lantern_id + 'rotation') * 20 - 10, // -10도에서 +10도 사이의 각도
       isFlipped: seededRandom((lantern as { lantern_id: string }).lantern_id + 'flip') > 0.5,
     })) as LanternWithRect[];
-  }, [data]);
+  }, [data, window.innerWidth]);
 
   // 내 풍등 완료 여부 확인
   useEffect(() => {

--- a/src/pages/lantern/Lantern.tsx
+++ b/src/pages/lantern/Lantern.tsx
@@ -65,6 +65,7 @@ const Lantern = () => {
   const [isMyLanternCompleted, setIsMyLanternCompleted] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [closeButtonRect, setCloseButtonRect] = useState<DOMRect | null>(null);
 
   // 풍등 정보 없을 경우 리다이렉트
   useEffect(() => {
@@ -73,17 +74,36 @@ const Lantern = () => {
     }
   }, [currentLanternId]);
 
+  useEffect(() => {
+    const updateCloseButtonRect = () => {
+      if (closeButtonRef.current) {
+        setCloseButtonRect(closeButtonRef.current.getBoundingClientRect());
+      }
+    };
+
+    // 컴포넌트 마운트 후 즉시 실행
+    updateCloseButtonRect();
+
+    window.addEventListener('resize', updateCloseButtonRect);
+    return () => {
+      window.removeEventListener('resize', updateCloseButtonRect);
+    };
+  }, []);
+
   const handleAlertConfirm = () => {
     navigate('/upload');
   };
 
   const lanterns = useMemo(() => {
+    if (!closeButtonRect || !data) return [];
+
     const ids = (data?.data ?? []).map((l) => l.lantern_id);
     const positionMap = generateNonOverlappingPositions(
       ids,
       window.innerWidth <= MOBILE_MIN_WIDTH ? 60 : 100,
       window.innerWidth <= MOBILE_MIN_WIDTH ? window.innerHeight : window.innerWidth,
       window.innerWidth <= MOBILE_MIN_WIDTH ? window.innerWidth : window.innerHeight,
+      closeButtonRect,
     );
     const lanternImages = [LanternImg1, LanternImg2];
 
@@ -97,7 +117,7 @@ const Lantern = () => {
       rotation: seededRandom((lantern as { lantern_id: string }).lantern_id + 'rotation') * 20 - 10, // -10도에서 +10도 사이의 각도
       isFlipped: seededRandom((lantern as { lantern_id: string }).lantern_id + 'flip') > 0.5,
     })) as LanternWithRect[];
-  }, [data, window.innerWidth]);
+  }, [data, window.innerWidth, window.innerHeight, closeButtonRect]);
 
   // 내 풍등 완료 여부 확인
   useEffect(() => {

--- a/src/pages/lantern/utils/index.ts
+++ b/src/pages/lantern/utils/index.ts
@@ -28,6 +28,7 @@ export const generateNonOverlappingPositions = (
   boxSize = 100,
   viewportWidth: number,
   viewportHeight: number,
+  excludeRect: DOMRect | null = null,
 ) => {
   const sortedIds = [...ids].sort();
   const padding = 12;
@@ -48,7 +49,10 @@ export const generateNonOverlappingPositions = (
       height: boxSize,
     };
 
-    while (Object.values(placed).some((other) => isRectOverlapping(position, other, 12))) {
+    while (
+      Object.values(placed).some((other) => isRectOverlapping(position, other, 12)) ||
+      (excludeRect && isRectOverlapping(position, excludeRect, 50))
+    ) {
       tries++;
       position = {
         x: padding + seededRandom(id + 'x' + tries) * maxX,

--- a/src/pages/lanternDetail/LanternDetail.css.ts
+++ b/src/pages/lanternDetail/LanternDetail.css.ts
@@ -2,6 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { Z_INDEX } from './constants/zIndex';
 import { colors } from '@/styles/color.css';
 import { fonts } from '@/styles/font.css';
+import { MOBILE_MIN_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 export const overlay = style({
   position: 'fixed',
@@ -12,6 +13,18 @@ export const overlay = style({
   backgroundColor: colors.color.black,
   zIndex: Z_INDEX.OVERLAY,
   overflow: 'hidden',
+
+  '@media': {
+    [MOBILE_MIN_MEDIA_QUERY]: {
+      transform: 'rotate(90deg)',
+      transformOrigin: 'center center',
+      width: '100vh',
+      height: '100vw',
+      position: 'fixed',
+      top: 'calc((100vh - 100vw) / 2)',
+      left: 'calc((100vw - 100vh) / 2)',
+    },
+  },
 });
 
 export const closeButton = style({

--- a/src/queries/lantern/useLanternProgress.ts
+++ b/src/queries/lantern/useLanternProgress.ts
@@ -1,0 +1,21 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { lanternKeys } from '../queryKey';
+import { MusicStatusData } from '@/apis/lantern/subscribeStatus';
+
+export const useCachedLanternProgress = (lanternId: string | null) => {
+  const queryClient = useQueryClient();
+
+  return useQuery({
+    queryKey: lanternKeys.progress(lanternId!),
+    queryFn: async () => {
+      const cached = queryClient.getQueryData<MusicStatusData | MusicStatusData[]>(lanternKeys.progress(lanternId!));
+      return cached || null;
+    },
+    enabled: !!lanternId,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+};

--- a/src/queries/lantern/useLanternProgress.ts
+++ b/src/queries/lantern/useLanternProgress.ts
@@ -6,9 +6,10 @@ export const useCachedLanternProgress = (lanternId: string | null) => {
   const queryClient = useQueryClient();
 
   return useQuery({
-    queryKey: lanternKeys.progress(lanternId!),
+    queryKey: lanternKeys.progress(lanternId ?? ''),
     queryFn: async () => {
-      const cached = queryClient.getQueryData<MusicStatusData | MusicStatusData[]>(lanternKeys.progress(lanternId!));
+      if (!lanternId) return null;
+      const cached = queryClient.getQueryData<MusicStatusData | MusicStatusData[]>(lanternKeys.progress(lanternId));
       return cached || null;
     },
     enabled: !!lanternId,

--- a/src/queries/lantern/useSubscribeStatus.ts
+++ b/src/queries/lantern/useSubscribeStatus.ts
@@ -19,7 +19,7 @@ export const useSubscribeStatus = ({ lanternId, onPartial, onDone, onError }: Us
     (data: MusicStatusData) => {
       onPartial?.(data);
     },
-    [onPartial, queryClient, progressQueryKey],
+    [onPartial],
   );
 
   const handleAllDone = useCallback(
@@ -30,7 +30,7 @@ export const useSubscribeStatus = ({ lanternId, onPartial, onDone, onError }: Us
 
       onDone?.();
     },
-    [lanternId, onDone, queryClient, progressQueryKey],
+    [onDone, queryClient, progressQueryKey],
   );
 
   const handleSseError = useCallback(

--- a/src/routes/SSELayout.tsx
+++ b/src/routes/SSELayout.tsx
@@ -18,7 +18,7 @@ export const SSELayout = () => {
   });
 
   useEffect(() => {
-    if (isCompleted) {
+    if (isCompleted && entryCode) {
       navigate(`/lanterns?currentLanternId=${entryCode}`);
     }
   }, [isCompleted, navigate, entryCode]);

--- a/src/routes/SSELayout.tsx
+++ b/src/routes/SSELayout.tsx
@@ -1,21 +1,27 @@
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Outlet, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useSubscribeStatus } from '@/queries/lantern/useSubscribeStatus';
 
 export const SSELayout = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const entryCode = (location.state as { lantern_id?: string })?.lantern_id;
+  const [searchParams] = useSearchParams();
+  const currentLanternId = searchParams.get('currentLanternId');
+  const entryCode = currentLanternId ?? (location.state as { lantern_id?: string })?.lantern_id;
+  const [isCompleted, setIsCompleted] = useState(false);
 
   useSubscribeStatus({
     lanternId: entryCode ?? '',
     onDone: () => {
-      const existingCodes = JSON.parse(localStorage.getItem('successLanterns') || '[]');
-      existingCodes.push(entryCode);
-      localStorage.setItem('successLanterns', JSON.stringify(existingCodes));
-
-      navigate(`/lanterns?currentLanternId=${entryCode}`);
+      setIsCompleted(true);
     },
   });
+
+  useEffect(() => {
+    if (isCompleted) {
+      navigate(`/lanterns?currentLanternId=${entryCode}`);
+    }
+  }, [isCompleted, navigate, entryCode]);
 
   return <Outlet />;
 };

--- a/src/styles/mediaQuery.ts
+++ b/src/styles/mediaQuery.ts
@@ -1,2 +1,4 @@
 export const MOBILE_MAX_WIDTH = 798;
+export const MOBILE_MIN_WIDTH = 480;
 export const MOBILE_MEDIA_QUERY = `screen and (max-width: ${MOBILE_MAX_WIDTH}px)`;
+export const MOBILE_MIN_MEDIA_QUERY = `screen and (max-width: ${MOBILE_MIN_WIDTH}px)`;


### PR DESCRIPTION
<!-- PR의 제목은 "feat: 로그인 기능 추가" 와 같이 작성해주세요! -->
<!-- 커밋 컨벤션과 PR 제목은 통일하고 스쿼시머지를 진행합니다 -->

## 🔢 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #38 

## 🎈 PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## 🔑 Key Changes
- MOBILE_MIN_WIDTH로425를 추가했습니다. 이를 기준으로 모바일 환경에서 목록과 상세페이지를 접속하면 90도 회전한 뷰로 보이도록 설정하였습니다.
- 모바일 환경에서는 손인식보다 클릭이벤트가 편하기 때문에 웹캠을 비활성화하도록 설정하고 클릭 이벤트를 추가했습니다.
- 목록에서 나가기 버튼을 추가했습니다. 모바일 환경에서는 화면이 작기 때문에 풍등 크기를 줄였지만, 나가기 버튼과 겹칠 우려가 있어 겹쳤는지 여부를 확인하는 부분에 나가기 버튼도 확인하도록 하였고 안정적으로 겹치지 않도록 50만큼의 공간을 두었습니다.
- 이미 생성이 완료된 풍등의 상태를 조회할 때, navigate를 SSELayout에서 done 내부에 두어 무한루프가 되는 이슈가 있었습니다. 외부로 꺼내주어 계속해서 연결을 시도하지 않도록 해결했습니다. 그리고 캐싱을 실시간으로 처리할 수 있도록 useLanternProgress 훅을 추가로 만들어서 사용했습니다.
- navigate의 state로 받아오는 entrycode만을 사용하여 sse를 요청하고 있어서, 목록 페이지에서 요청이 누락되는 경우가 있었습니다. 쿼리파라미터의 값이 있다면 그 값을 기준으로 생성 상태를 조회하도록 추가하였습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

## 📢 To Reviewers
제가 누락한 부분이 있을 수 있습니다........
<!-- 함께 의논할 부분이 있다면 작성해주세요 -->

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료
<img width="540" height="887" alt="image" src="https://github.com/user-attachments/assets/1ad8868e-9d0d-4ab7-b085-5ae565fb0c87" />

<!-- 참고 레퍼런스를 첨부해주세요.  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 모바일 화면에서 비디오 피드가 비활성화됩니다.
  * Lantern 상세 및 오버레이 화면이 모바일 환경에서 세로로 회전되어 표시됩니다.
  * Lantern 화면에 닫기 버튼이 추가되고, 닫기 제스처와 이동 기능이 지원됩니다.
  * Lantern 아이템 클릭 시 상세 화면으로 이동할 수 있습니다.
  * Lantern 진행 상태를 캐시에서 조회하는 기능이 추가되었습니다.

* **버그 수정**
  * Lantern 아이템의 위치가 닫기 버튼과 겹치지 않도록 개선되었습니다.

* **스타일**
  * 모바일 환경에서 레이아웃이 자동으로 회전 및 재배치되어 가독성이 향상되었습니다.

* **기타**
  * 모바일 대응을 위한 미디어 쿼리 및 상수가 추가되었습니다.
  * Lantern 진행 상태 관련 내부 로직이 개선되었습니다.
  * Lantern 완료 후 자동 이동 방식이 개선되어 URL 파라미터 기반으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->